### PR TITLE
fix: update yarn lock to correctly fetch assembly script

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4868,9 +4868,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"
@@ -7847,9 +7847,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.649:
-  version "1.3.684"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz#053fbb0a4b2d5c076dfa6e1d8ecd06a3075a558a"
-  integrity sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w==
+  version "1.3.685"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.685.tgz#f636d17c9c232c925f8bbfbff4f86303da091ff9"
+  integrity sha512-C3oFZNkJ8lz85ADqr3hzpjBc2ciejMRN2SCd/D0hwcqpr6MGxfdN/j89VN6l+ERTuCUvhg0VYsf40Q4qTz4bhQ==
 
 elliptic@6.3.3:
   version "6.3.3"
@@ -8500,9 +8500,9 @@ eth-rpc-errors@^3.0.0:
     fast-safe-stringify "^2.0.6"
 
 eth-rpc-errors@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz#11bc164e25237a679061ac05b7da7537b673d3b7"
-  integrity sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz#6ddb6190a4bf360afda82790bb7d9d5e724f423a"
+  integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==
   dependencies:
     fast-safe-stringify "^2.0.6"
 


### PR DESCRIPTION
As title, otherwise you get the following when cloning + running. I deleted yarn.lock and re-ran yarn.

# Steps to repro
```
git clone https://github.com/ethereum-optimism/optimism-gateway
cd optimism-gateway
yarn
```

# Logs
```
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error Couldn't find match for "36040d5b5312f19a025782b5e36663823494c2f3" in "refs/heads/air,refs/heads/asc-encoding,refs/heads/asm-div,refs/heads/aspublish,refs/heads/backport-minor,refs/heads/binary-refactor,refs/heads/binaryen-reftypes,refs/heads/eqeqeq,refs/heads/esm-loader,refs/heads/externref-bind,refs/heads/fix-asinit-default-test,refs/heads/fix-asmjs,refs/heads/fix-binary-util,refs/heads/fix-browser-asc,refs/heads/fix-functionArg,refs/heads/fix-getRandomValues,refs/heads/fix-minimal,refs/heads/fix-newArray,refs/heads/fix-runpasses-oneoff,refs/heads/fix-sourcemap-column,refs/heads/fix-startorder,refs/heads/fix-staticarray-id,refs/heads/fix-staticmem,refs/heads/inc,refs/heads/issue-1186,refs/heads/issue-1374,refs/heads/issue-1379,refs/heads/issue-1386,refs/heads/issue-1398,refs/heads/issue-1400,refs/heads/issue-1404,refs/heads/issue-1409,refs/heads/issue-1483,refs/heads/issue-1536,refs/heads/issue-1547,refs/heads/issue-1585,refs/heads/issue-1599,refs/heads/issue-1622,refs/heads/issue-1637,refs/heads/issue-1644,refs/heads/issue-1652,refs/heads/issue-1654,refs/heads/issue-1673,refs/heads/issue-1675,refs/heads/issue-1677,refs/heads/itcms-coldstart,refs/heads/loader-esm,refs/heads/master,refs/heads/memoryData,refs/heads/nontrapping-f2i,refs/heads/notempfree,refs/heads/nullish,refs/heads/optimize-shadowstack,refs/heads/package-exports,refs/heads/release,refs/heads/relocatable,refs/heads/rtrace-constants,refs/heads/rtrace-esm,refs/heads/rtrace-shadow,refs/heads/scopeanalyzer,refs/heads/simd-types,refs/heads/size-tostring,refs/heads/stw,refs/heads/stw-backport,refs/heads/stw-mathdiff,refs/heads/template-literal-parsing,refs/heads/threadsafe,refs/heads/throw-try-catch,refs/heads/tracing-prep,refs/heads/trim-data-segments,refs/heads/try-catch,refs/heads/unify-ensure-ctor,refs/heads/update-binaryen,refs/heads/update-deps,refs/heads/update-rtrace-defs,refs/heads/zeroseventeen-comments,refs/tags/v0.10.0,refs/tags/v0.10.0-nightly.20200517,refs/tags/v0.10.0-nightly.20200526,refs/tags/v0.10.0-nightly.20200528,refs/tags/v0.10.0-nightly.20200529,refs/tags/v0.10.0-nightly.20200530,refs/tags/v0.10.0-nightly.20200610,refs/tags/v0.10.0-nightly.20200611,refs/tags/v0.10.1,refs/tags/v0.10.2,refs/tags/v0.11.0,refs/tags/v0.12.0,refs/tags/v0.12.1,refs/tags/v0.12.2,refs/tags/v0.12.3,refs/tags/v0.12.4,refs/tags/v0.12.5,refs/tags/v0.12.6,refs/tags/v0.13.0,refs/tags/v0.13.1,refs/tags/v0.13.2,refs/tags/v0.13.3,refs/tags/v0.13.4,refs/tags/v0.13.5,refs/tags/v0.13.6,refs/tags/v0.13.7,refs/tags/v0.13.8,refs/tags/v0.14.0,refs/tags/v0.14.1,refs/tags/v0.14.10,refs/tags/v0.14.11,refs/tags/v0.14.12,refs/tags/v0.14.13,refs/tags/v0.14.2,refs/tags/v0.14.3,refs/tags/v0.14.4,refs/tags/v0.14.5,refs/tags/v0.14.6,refs/tags/v0.14.7,refs/tags/v0.14.8,refs/tags/v0.14.9,refs/tags/v0.15.0,refs/tags/v0.15.1,refs/tags/v0.15.2,refs/tags/v0.16.0,refs/tags/v0.16.1,refs/tags/v0.17.0,refs/tags/v0.17.1,refs/tags/v0.17.10,refs/tags/v0.17.11,refs/tags/v0.17.12,refs/tags/v0.17.13,refs/tags/v0.17.14,refs/tags/v0.17.2,refs/tags/v0.17.3,refs/tags/v0.17.4,refs/tags/v0.17.5,refs/tags/v0.17.6,refs/tags/v0.17.7,refs/tags/v0.17.8,refs/tags/v0.17.9,refs/tags/v0.18.0,refs/tags/v0.18.1,refs/tags/v0.18.10,refs/tags/v0.18.11,refs/tags/v0.18.12,refs/tags/v0.18.13,refs/tags/v0.18.14,refs/tags/v0.18.2,refs/tags/v0.18.3,refs/tags/v0.18.4,refs/tags/v0.18.5,refs/tags/v0.18.6,refs/tags/v0.18.7,refs/tags/v0.18.8,refs/tags/v0.18.9,refs/tags/v0.6,refs/tags/v0.8.0,refs/tags/v0.8.0-nightly.20191109,refs/tags/v0.8.0-nightly.20191110,refs/tags/v0.8.0-nightly.20191114,refs/tags/v0.8.0-nightly.20191115,refs/tags/v0.8.0-nightly.20191117,refs/tags/v0.8.1,refs/tags/v0.8.1-nightly.20191119,refs/tags/v0.8.1-nightly.20191121,refs/tags/v0.8.1-nightly.20191124,refs/tags/v0.8.1-nightly.20191130,refs/tags/v0.8.1-nightly.20191201,refs/tags/v0.8.1-nightly.20191205,refs/tags/v0.8.1-nightly.20191208,refs/tags/v0.8.1-nightly.20191209,refs/tags/v0.8.1-nightly.20191214,refs/tags/v0.8.1-nightly.20191218,refs/tags/v0.8.1-nightly.20191219,refs/tags/v0.8.1-nightly.20191220,refs/tags/v0.8.1-nightly.20191221,refs/tags/v0.8.1-nightly.20191228,refs/tags/v0.8.1-nightly.20191229,refs/tags/v0.8.1-nightly.20200101,refs/tags/v0.8.1-nightly.20200102,refs/tags/v0.8.1-nightly.20200110,refs/tags/v0.8.1-nightly.20200111,refs/tags/v0.8.1-nightly.20200112,refs/tags/v0.8.1-nightly.20200114,refs/tags/v0.8.1-nightly.20200119,refs/tags/v0.8.1-nightly.20200120,refs/tags/v0.8.1-nightly.20200123,refs/tags/v0.8.1-nightly.20200125,refs/tags/v0.9.0,refs/tags/v0.9.0-nightly.20200127,refs/tags/v0.9.0-nightly.20200129,refs/tags/v0.9.1,refs/tags/v0.9.1-nightly.20200131,refs/tags/v0.9.1-nightly.20200209,refs/tags/v0.9.1-nightly.20200210,refs/tags/v0.9.1-nightly.20200212,refs/tags/v0.9.2,refs/tags/v0.9.2-nightly.20200227,refs/tags/v0.9.2-nightly.20200228,refs/tags/v0.9.2-nightly.20200304,refs/tags/v0.9.2-nightly.20200310,refs/tags/v0.9.3,refs/tags/v0.9.4,refs/tags/v0.9.4-nightly.20200314,refs/tags/v0.9.4-nightly.20200315,refs/tags/v0.9.4-nightly.20200316,refs/tags/v0.9.4-nightly.20200325,refs/tags/v0.9.4-nightly.20200329,refs/tags/v0.9.4-nightly.20200401,refs/tags/v0.9.4-nightly.20200402,refs/tags/v0.9.4-nightly.20200411,refs/tags/v0.9.4-nightly.20200413,refs/tags/v0.9.4-nightly.20200414,refs/tags/v0.9.4-nightly.20200416,refs/tags/v0.9.4-nightly.20200421,refs/tags/v0.9.4-nightly.20200422,refs/tags/v0.9.4-nightly.20200423,refs/tags/v0.9.4-nightly.20200427,refs/tags/v0.9.4-nightly.20200428,refs/tags/v0.9.4-nightly.20200429,refs/tags/v0.9.4-nightly.20200430,refs/tags/v0.9.4-nightly.20200506,refs/tags/v0.9.4-nightly.20200509,refs/tags/v0.9.4-nightly.20200510,refs/tags/v0.9.4-nightly.20200514" for "https://github.com/AssemblyScript/assemblyscript".
```
